### PR TITLE
Added backup font for .tag-header, fixed typo in Helvetica Neue

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -143,7 +143,7 @@ article {
     margin-bottom: 5px;
 }
 .label a {
-    font: 75% -apple-system, Roboto, Helvetica-Neue, Helvetica, "Open Sans", Arial, sans-serif;
+    font: 75% -apple-system, Roboto, Helvetica Neue, Helvetica, "Open Sans", Arial, sans-serif;
     font-weight: 300 !important;
     color: #ffffff;
 }
@@ -161,7 +161,7 @@ article {
     text-decoration: none;
 }
 .tag-header {
-    font-family: Raleway;
+    font-family: Raleway, Helvetica;
     text-transform: uppercase;
 }
 hr {


### PR DESCRIPTION
- `.tag-header` had the same problem as #1 manifest on GitHub Pages, so I corrected it as well
- Also, `Helvetica Neue` had an erroneous hyphen in one place that I removed
