### PR TITLE
tags/index.html closes <section>

### DIFF
--- a/tags/index.html
+++ b/tags/index.html
@@ -53,3 +53,4 @@ group: navigation
     {% assign group = nil %}
   </ul>
 {% endfor %}
+</section>


### PR DESCRIPTION
Without this, anything in `_includes/footer.html` would be a child of `<section id="tags">` rather than a direct descendant of `<body>`.  This can lead to inheriting the wrong styles